### PR TITLE
Bump octopus-base reusable workflows to v2.1.11

### DIFF
--- a/.github/workflows/build-gradle-hybrid-docker.yml
+++ b/.github/workflows/build-gradle-hybrid-docker.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.11
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/build-gradle-hybrid-docker.yml
+++ b/.github/workflows/build-gradle-hybrid-docker.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.11
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.12
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/build-gradle-hybrid.yml
+++ b/.github/workflows/build-gradle-hybrid.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.11
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/build-gradle-hybrid.yml
+++ b/.github/workflows/build-gradle-hybrid.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.11
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.12
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/build-gradle-public.yml
+++ b/.github/workflows/build-gradle-public.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.11
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.12
     with:
       flow-type: public
       java-version: '11'

--- a/.github/workflows/build-gradle-public.yml
+++ b/.github/workflows/build-gradle-public.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.11
     with:
       flow-type: public
       java-version: '11'

--- a/.github/workflows/build-maven-public.yml
+++ b/.github/workflows/build-maven-public.yml
@@ -4,6 +4,6 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.1.11
     with:
       java-version: '11'

--- a/.github/workflows/build-maven-public.yml
+++ b/.github/workflows/build-maven-public.yml
@@ -4,6 +4,6 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.1.11
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.1.12
     with:
       java-version: '11'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,9 +8,8 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.11
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.12
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"
     secrets: inherit
-

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,10 +8,9 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.11
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"
     secrets: inherit
-
 

--- a/.github/workflows/release-gradle-hybrid-docker.yml
+++ b/.github/workflows/release-gradle-hybrid-docker.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.11
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.12
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/release-gradle-hybrid-docker.yml
+++ b/.github/workflows/release-gradle-hybrid-docker.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.11
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/release-gradle-hybrid.yml
+++ b/.github/workflows/release-gradle-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.11
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.12
     with:
       flow-type: hybrid
       java-version: '11' 

--- a/.github/workflows/release-gradle-hybrid.yml
+++ b/.github/workflows/release-gradle-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.11
     with:
       flow-type: hybrid
       java-version: '11' 

--- a/.github/workflows/release-gradle-public.yml
+++ b/.github/workflows/release-gradle-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.11
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.12
     with:
       flow-type: public
       java-version: '11'

--- a/.github/workflows/release-gradle-public.yml
+++ b/.github/workflows/release-gradle-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.11
     with:
       flow-type: public
       java-version: '11'

--- a/.github/workflows/release-maven-hybrid.yml
+++ b/.github/workflows/release-maven-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.1.11
     with:
       flow-type: hybrid
       java-version: '8'

--- a/.github/workflows/release-maven-hybrid.yml
+++ b/.github/workflows/release-maven-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.1.11
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.1.12
     with:
       flow-type: hybrid
       java-version: '8'

--- a/.github/workflows/release-maven-public.yml
+++ b/.github/workflows/release-maven-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.1.11
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.1.12
     with:
       flow-type: public
       java-version: '11'

--- a/.github/workflows/release-maven-public.yml
+++ b/.github/workflows/release-maven-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.1.11
     with:
       flow-type: public
       java-version: '11'

--- a/.github/workflows/test-check-artifact.yml
+++ b/.github/workflows/test-check-artifact.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.11
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.12
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"
     secrets: inherit

--- a/.github/workflows/test-check-artifact.yml
+++ b/.github/workflows/test-check-artifact.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.11
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"
     secrets: inherit

--- a/.github/workflows/test-register-release.yml
+++ b/.github/workflows/test-register-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.1.11
     with:
       octopus-repository: ${{ inputs.octopus-repository }}
       release-version:  ${{ inputs.release-version }}

--- a/.github/workflows/test-register-release.yml
+++ b/.github/workflows/test-register-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.1.11
+    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.1.12
     with:
       octopus-repository: ${{ inputs.octopus-repository }}
       release-version:  ${{ inputs.release-version }}


### PR DESCRIPTION
Updates all octopus-base reusable workflow references in octopus-test from v2.1.8 to v2.1.11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow references to v2.1.12 across build, release, and test pipelines to use the latest shared workflow implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->