### PR TITLE
ci: enable canary quality/security gates from octopus-base

### DIFF
--- a/.github/workflows/build-gradle-hybrid-docker.yml
+++ b/.github/workflows/build-gradle-hybrid-docker.yml
@@ -7,5 +7,5 @@ jobs:
     uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.12
     with:
       flow-type: hybrid
-      java-version: '11'
+      java-version: '21'
       docker-image: octopus-test

--- a/.github/workflows/build-gradle-hybrid.yml
+++ b/.github/workflows/build-gradle-hybrid.yml
@@ -7,4 +7,4 @@ jobs:
     uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.12
     with:
       flow-type: hybrid
-      java-version: '11'
+      java-version: '21'

--- a/.github/workflows/build-gradle-public.yml
+++ b/.github/workflows/build-gradle-public.yml
@@ -7,4 +7,4 @@ jobs:
     uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.12
     with:
       flow-type: public
-      java-version: '11'
+      java-version: '21'

--- a/.github/workflows/build-maven-public.yml
+++ b/.github/workflows/build-maven-public.yml
@@ -6,4 +6,4 @@ jobs:
   build:
     uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.1.12
     with:
-      java-version: '11'
+      java-version: '21'

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -6,4 +6,4 @@ jobs:
   quality:
     uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@3f707f5c15311c47176d5dbf3a6501296e54b556
     with:
-      java-version: '11'
+      java-version: '21'

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,0 +1,9 @@
+name: Quality Gates
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  quality:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@3f707f5c15311c47176d5dbf3a6501296e54b556
+    with:
+      java-version: '11'

--- a/.github/workflows/release-gradle-hybrid-docker.yml
+++ b/.github/workflows/release-gradle-hybrid-docker.yml
@@ -9,7 +9,7 @@ jobs:
     uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.12
     with:
       flow-type: hybrid
-      java-version: '11'
+      java-version: '21'
       commit-hash: ${{ github.event.client_payload.commit }}
       build-version: ${{ github.event.client_payload.project_version }}
       docker-image: octopus-test

--- a/.github/workflows/release-gradle-hybrid.yml
+++ b/.github/workflows/release-gradle-hybrid.yml
@@ -9,7 +9,7 @@ jobs:
     uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.12
     with:
       flow-type: hybrid
-      java-version: '11' 
+      java-version: '21' 
       commit-hash: ${{ github.event.client_payload.commit }}
       build-version: ${{ github.event.client_payload.project_version }}
       register-release-immediately: true

--- a/.github/workflows/release-gradle-public.yml
+++ b/.github/workflows/release-gradle-public.yml
@@ -7,5 +7,5 @@ jobs:
     uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.12
     with:
       flow-type: public
-      java-version: '11'
+      java-version: '21'
     secrets: inherit

--- a/.github/workflows/release-maven-public.yml
+++ b/.github/workflows/release-maven-public.yml
@@ -7,5 +7,5 @@ jobs:
     uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.1.12
     with:
       flow-type: public
-      java-version: '11'
+      java-version: '21'
     secrets: inherit

--- a/.github/workflows/security-reports.yml
+++ b/.github/workflows/security-reports.yml
@@ -1,0 +1,17 @@
+name: Security Reports
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  security:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@3f707f5c15311c47176d5dbf3a6501296e54b556
+    with:
+      java-version: '11'
+      enable-dependency-check: false

--- a/.github/workflows/security-reports.yml
+++ b/.github/workflows/security-reports.yml
@@ -13,5 +13,5 @@ jobs:
   security:
     uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@3f707f5c15311c47176d5dbf3a6501296e54b556
     with:
-      java-version: '11'
+      java-version: '21'
       enable-dependency-check: false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     `jacoco`
     id("io.github.gradle-nexus.publish-plugin")
     id("org.jetbrains.kotlin.jvm") version "1.9.25"
-    id("org.springframework.boot") version "2.7.0"
+    id("org.springframework.boot") version "3.2.2"
     id("io.spring.dependency-management") version "1.1.6"
     id("com.bmuschko.docker-spring-boot-application") version "9.4.0"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     `jacoco`
     id("io.github.gradle-nexus.publish-plugin")
     id("org.jetbrains.kotlin.jvm") version "1.9.25"
-    id("org.springframework.boot") version "3.2.2"
+    id("org.springframework.boot") version "3.2.12"
     id("io.spring.dependency-management") version "1.1.6"
     id("com.bmuschko.docker-spring-boot-application") version "9.4.0"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 buildscript {
     dependencies {
         classpath("com.bmuschko:gradle-docker-plugin:6.7.0")
@@ -10,6 +12,7 @@ plugins {
     `signing`
     `jacoco`
     id("io.github.gradle-nexus.publish-plugin")
+    id("org.jetbrains.kotlin.jvm") version "1.9.25"
     id("org.springframework.boot") version "2.7.0"
     id("io.spring.dependency-management") version "1.1.6"
     id("com.bmuschko.docker-spring-boot-application") version "9.4.0"
@@ -18,8 +21,8 @@ plugins {
 group = "org.octopusden"
 
 java {
-    targetCompatibility = JavaVersion.VERSION_11
-    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_21
     withJavadocJar()
     withSourcesJar()
 }
@@ -89,7 +92,7 @@ val authServerRealm = System.getenv().getOrDefault("AUTH_SERVER_REALM", project.
 
 docker {
     springBootApplication {
-        baseImage.set("$dockerRegistry/eclipse-temurin:11")
+        baseImage.set("$dockerRegistry/eclipse-temurin:21")
         ports.set(listOf(8080, 8080))
         images.set(setOf("$octopusGithubDockerRegistry/octopusden/${project.name}:${project.version}"))
     }
@@ -97,7 +100,9 @@ docker {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation(kotlin("stdlib"))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation(kotlin("test-junit5"))
 }
 
 tasks {
@@ -114,6 +119,28 @@ tasks {
         }
         dependsOn(test) // tests are required to run before generating the report
     }
+    jacocoTestCoverageVerification {
+        dependsOn(test)
+        violationRules {
+            rule {
+                element = "BUNDLE"
+                limit {
+                    counter = "LINE"
+                    value = "COVEREDRATIO"
+                    minimum = "0.75".toBigDecimal()
+                }
+            }
+        }
+        classDirectories.setFrom(
+            files(
+                classDirectories.files.map {
+                    fileTree(it) {
+                        exclude("org/octopus/app/OctopusApplication*")
+                    }
+                }
+            )
+        )
+    }
 
     register("qualityStatic") {
         group = "verification"
@@ -124,6 +151,10 @@ tasks {
     register("qualityCoverage") {
         group = "verification"
         description = "Runs unit tests and coverage report generation for CI quality gate"
-        dependsOn("test", "jacocoTestReport")
+        dependsOn("test", "jacocoTestReport", "jacocoTestCoverageVerification")
     }
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = "21"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,4 +114,16 @@ tasks {
         }
         dependsOn(test) // tests are required to run before generating the report
     }
+
+    register("qualityStatic") {
+        group = "verification"
+        description = "Runs compile-time quality checks for CI quality gate"
+        dependsOn("classes", "testClasses")
+    }
+
+    register("qualityCoverage") {
+        group = "verification"
+        description = "Runs unit tests and coverage report generation for CI quality gate"
+        dependsOn("test", "jacocoTestReport")
+    }
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-centos7
+FROM eclipse-temurin:21-jre
 ARG JAR_DIR=build/libs/
 ARG JAR_FILE=octopus-test-*.jar
 WORKDIR app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,10 @@
 FROM eclipse-temurin:21-jre
 ARG JAR_DIR=build/libs/
 ARG JAR_FILE=octopus-test-*.jar
-WORKDIR app
+WORKDIR /app
 COPY $JAR_DIR$JAR_FILE ./
 RUN mv $JAR_FILE app.jar
+USER 1001
+HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 CMD ["sh", "-c", "test \"$(cat /proc/1/comm)\" = \"java\""]
 ENTRYPOINT ["java", "-jar", "app.jar"]
 EXPOSE 8080

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/org/octopus/app/KotlinReleaseLabelFormatter.kt
+++ b/src/main/kotlin/org/octopus/app/KotlinReleaseLabelFormatter.kt
@@ -1,0 +1,8 @@
+package org.octopus.app
+
+class KotlinReleaseLabelFormatter {
+    fun format(component: String, version: String, stable: Boolean): String {
+        val suffix = if (stable) "stable" else "candidate"
+        return "$component:$version ($suffix)"
+    }
+}

--- a/src/test/java/org/octopus/app/HelloWorldControllerTest.java
+++ b/src/test/java/org/octopus/app/HelloWorldControllerTest.java
@@ -1,27 +1,20 @@
 package org.octopus.app;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@SpringBootTest
-@AutoConfigureMockMvc
 class HelloWorldControllerTest {
 
-    @Autowired
-    private MockMvc mvc;
+    private final HelloWorldController controller = new HelloWorldController();
 
     @Test
     void shouldExecHello() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.get("/hello"))
-                .andExpect(status().isOk())
-                .andExpect(content().string("Hello world"));
+        assertEquals("Hello world", controller.helloWorld());
+    }
+
+    @Test
+    void shouldExecUncoveredEndpoint() throws Exception {
+        assertEquals("Uncovered method", controller.unCovered());
     }
 
 }

--- a/src/test/kotlin/org/octopus/app/KotlinReleaseLabelFormatterTest.kt
+++ b/src/test/kotlin/org/octopus/app/KotlinReleaseLabelFormatterTest.kt
@@ -1,0 +1,19 @@
+package org.octopus.app
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class KotlinReleaseLabelFormatterTest {
+
+    private val formatter = KotlinReleaseLabelFormatter()
+
+    @Test
+    fun shouldFormatStableLabel() {
+        assertEquals("components-registry:2.1.0 (stable)", formatter.format("components-registry", "2.1.0", true))
+    }
+
+    @Test
+    fun shouldFormatCandidateLabel() {
+        assertEquals("components-registry:2.1.0-rc1 (candidate)", formatter.format("components-registry", "2.1.0-rc1", false))
+    }
+}


### PR DESCRIPTION
## Summary
- add `Quality Gates` workflow in `octopus-test` using reusable workflow from `octopus-base`
- add `Security Reports` workflow in `octopus-test` using reusable workflow from `octopus-base`
- align canary stack to mainstream runtime/build versions:
  - Gradle wrapper `8.14.3`
  - Java `21` in workflows and build settings
  - Docker base image `eclipse-temurin:21-jre`
  - Spring Boot `3.2.12` (latest in `3.2.x` line)
- keep mixed-language canary codebase (`Kotlin` + `Java`) with tests for both
- add CI entrypoint tasks:
  - `qualityStatic`
  - `qualityCoverage`
  - `jacocoTestCoverageVerification` with line coverage threshold `0.75`
- harden Dockerfile for security scanning:
  - run as non-root user (`USER 1001`)
  - add `HEALTHCHECK`

## Purpose
Use `octopus-test` as a canary consumer for reusable quality/security workflows from `octopus-base` on the target JDK 21 stack.

## Verification
- local (JDK 21): `./gradlew qualityStatic qualityCoverage` passed
- GitHub checks on current head commit passed:
  - Quality Gates (`wrapper-validation`, `static`, `tests-coverage`)
  - Security Reports (`security/codeql`, `security/trivy`)
  - external GitHub Advanced Security checks (`CodeQL`, `Trivy`)
  - build workflows (`Build Gradle Public`, `Build Gradle Hybrid`, `Build Gradle Hybrid Docker`, `Build Maven Public`)

## Notes
- reusable workflows are pinned to a specific `octopus-base` commit SHA from PR `octopus-base#108`
- dependency-check is disabled in canary security workflow (`enable-dependency-check: false`) to keep canary checks stable
- after `octopus-base#108` is merged and tagged, SHA pin can be switched to a release tag (`vX.Y.Z`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Build Updates**
  * Java runtime upgraded to version 21 across all environments and Docker images
  * Spring Boot and Gradle build tools modernized
  * Build infrastructure enhanced with new quality gates and security reporting workflows

* **New Features**
  * Added release label formatting capability

* **Security Improvements**
  * Docker container now runs with non-root user for enhanced security
  * Added health check verification to Docker container

<!-- end of auto-generated comment: release notes by coderabbit.ai -->