### PR TITLE
ci: add release smoke tests to merge gate

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -47,6 +47,10 @@ jobs:
     with:
       java-version: "21"
 
+  release-smoke:
+    name: release-smoke
+    uses: ./.github/workflows/release-smoke.yml
+
   gate-merge:
     name: gate/merge
     if: ${{ always() }}
@@ -57,6 +61,7 @@ jobs:
       - build-gradle-hybrid
       - build-gradle-hybrid-docker
       - build-maven-public
+      - release-smoke
     runs-on: ubuntu-latest
     steps:
       - name: Validate gate results

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,61 @@
+name: Release Smoke Tests
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-gradle-public:
+    name: release/gradle-public
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@feature/common-quality-gates
+    with:
+      flow-type: public
+      java-version: "21"
+      dry-run: true
+    secrets: inherit
+
+  release-gradle-hybrid:
+    name: release/gradle-hybrid
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@feature/common-quality-gates
+    with:
+      flow-type: hybrid
+      java-version: "21"
+      commit-hash: ${{ github.sha }}
+      build-version: 0.0.0-smoke-${{ github.run_number }}
+      dry-run: true
+    secrets: inherit
+
+  release-gradle-hybrid-docker:
+    name: release/gradle-hybrid-docker
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@feature/common-quality-gates
+    with:
+      flow-type: hybrid
+      java-version: "21"
+      commit-hash: ${{ github.sha }}
+      build-version: 0.0.0-smoke-${{ github.run_number }}
+      docker-image: octopus-test
+      dry-run: true
+    secrets: inherit
+
+  release-maven-public:
+    name: release/maven-public
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@feature/common-quality-gates
+    with:
+      flow-type: public
+      java-version: "21"
+      dry-run: true
+    secrets: inherit
+
+  release-maven-hybrid:
+    name: release/maven-hybrid
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@feature/common-quality-gates
+    with:
+      flow-type: hybrid
+      java-version: "21"
+      commit-hash: ${{ github.sha }}
+      build-version: 0.0.0-smoke-${{ github.run_number }}
+      dry-run: true
+    secrets: inherit

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
 
 jobs:
+  # Execute reusable release flows without publish side effects.
   release-gradle-public:
     name: release/gradle-public
     uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@feature/common-quality-gates


### PR DESCRIPTION
## Summary
- add dry-run release smoke coverage for reusable release workflows
- include release smoke in the existing Merge Gate contract
- keep the external required check unchanged via gate/merge

## How to review
- open the Merge Gate run and verify that release smoke jobs execute the reusable release workflows without publish side effects
- confirm that gate/merge now aggregates release-smoke together with quality, security, and build jobs

## Notes
- this relies on octopus-base branch feature/common-quality-gates, where reusable Gradle and Maven release workflows now support dry-run mode
- the developer-facing merge contract remains Merge Gate / gate/merge