### PR TITLE
chore(ci): bump octopus-base reusable workflows to 2.4.1 (Phase 4)

### DIFF
--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -21,21 +21,21 @@ jobs:
 
   build-gradle-public:
     name: build/gradle-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
     with:
       flow-type: public
       java-version: "21"
 
   build-gradle-hybrid:
     name: build/gradle-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: "21"
 
   build-gradle-hybrid-docker:
     name: build/gradle-hybrid-docker
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: "21"
@@ -43,7 +43,7 @@ jobs:
 
   build-maven-public:
     name: build/maven-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.4.1
     with:
       java-version: "21"
 

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -21,21 +21,21 @@ jobs:
 
   build-gradle-public:
     name: build/gradle-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
     with:
       flow-type: public
       java-version: "21"
 
   build-gradle-hybrid:
     name: build/gradle-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: "21"
 
   build-gradle-hybrid-docker:
     name: build/gradle-hybrid-docker
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: "21"
@@ -43,7 +43,7 @@ jobs:
 
   build-maven-public:
     name: build/maven-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.3.5
     with:
       java-version: "21"
 

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -21,21 +21,21 @@ jobs:
 
   build-gradle-public:
     name: build/gradle-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
     with:
       flow-type: public
       java-version: "21"
 
   build-gradle-hybrid:
     name: build/gradle-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: "21"
 
   build-gradle-hybrid-docker:
     name: build/gradle-hybrid-docker
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: "21"
@@ -43,7 +43,7 @@ jobs:
 
   build-maven-public:
     name: build/maven-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.4.0
     with:
       java-version: "21"
 

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
     with:
       java-version: '21'

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.0
     with:
       java-version: '21'

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
     with:
       java-version: '21'

--- a/.github/workflows/release-gradle-hybrid-docker.yml
+++ b/.github/workflows/release-gradle-hybrid-docker.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release-gradle-hybrid-docker.yml
+++ b/.github/workflows/release-gradle-hybrid-docker.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release-gradle-hybrid-docker.yml
+++ b/.github/workflows/release-gradle-hybrid-docker.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release-gradle-hybrid.yml
+++ b/.github/workflows/release-gradle-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: '21' 

--- a/.github/workflows/release-gradle-hybrid.yml
+++ b/.github/workflows/release-gradle-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '21' 

--- a/.github/workflows/release-gradle-hybrid.yml
+++ b/.github/workflows/release-gradle-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '21' 

--- a/.github/workflows/release-gradle-public.yml
+++ b/.github/workflows/release-gradle-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
     with:
       flow-type: public
       java-version: '21'

--- a/.github/workflows/release-gradle-public.yml
+++ b/.github/workflows/release-gradle-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
     with:
       flow-type: public
       java-version: '21'

--- a/.github/workflows/release-gradle-public.yml
+++ b/.github/workflows/release-gradle-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
     with:
       flow-type: public
       java-version: '21'

--- a/.github/workflows/release-maven-hybrid.yml
+++ b/.github/workflows/release-maven-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: '8'

--- a/.github/workflows/release-maven-hybrid.yml
+++ b/.github/workflows/release-maven-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '8'

--- a/.github/workflows/release-maven-hybrid.yml
+++ b/.github/workflows/release-maven-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '8'

--- a/.github/workflows/release-maven-public.yml
+++ b/.github/workflows/release-maven-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.1
     with:
       flow-type: public
       java-version: '21'

--- a/.github/workflows/release-maven-public.yml
+++ b/.github/workflows/release-maven-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.3.5
     with:
       flow-type: public
       java-version: '21'

--- a/.github/workflows/release-maven-public.yml
+++ b/.github/workflows/release-maven-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.0
     with:
       flow-type: public
       java-version: '21'

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -11,7 +11,7 @@ jobs:
   # Execute reusable release flows without publish side effects.
   release-gradle-public:
     name: release/gradle-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
     with:
       flow-type: public
       java-version: "21"
@@ -20,7 +20,7 @@ jobs:
 
   release-gradle-hybrid:
     name: release/gradle-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: "21"
@@ -31,7 +31,7 @@ jobs:
 
   release-gradle-hybrid-docker:
     name: release/gradle-hybrid-docker
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: "21"
@@ -43,7 +43,7 @@ jobs:
 
   release-maven-public:
     name: release/maven-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.1
     with:
       flow-type: public
       java-version: "21"
@@ -52,7 +52,7 @@ jobs:
 
   release-maven-hybrid:
     name: release/maven-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: "21"

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -11,7 +11,7 @@ jobs:
   # Execute reusable release flows without publish side effects.
   release-gradle-public:
     name: release/gradle-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
     with:
       flow-type: public
       java-version: "21"
@@ -20,7 +20,7 @@ jobs:
 
   release-gradle-hybrid:
     name: release/gradle-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: "21"
@@ -31,7 +31,7 @@ jobs:
 
   release-gradle-hybrid-docker:
     name: release/gradle-hybrid-docker
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: "21"
@@ -43,7 +43,7 @@ jobs:
 
   release-maven-public:
     name: release/maven-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.3.5
     with:
       flow-type: public
       java-version: "21"
@@ -52,7 +52,7 @@ jobs:
 
   release-maven-hybrid:
     name: release/maven-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: "21"

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -11,7 +11,7 @@ jobs:
   # Execute reusable release flows without publish side effects.
   release-gradle-public:
     name: release/gradle-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
     with:
       flow-type: public
       java-version: "21"
@@ -20,7 +20,7 @@ jobs:
 
   release-gradle-hybrid:
     name: release/gradle-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: "21"
@@ -31,7 +31,7 @@ jobs:
 
   release-gradle-hybrid-docker:
     name: release/gradle-hybrid-docker
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: "21"
@@ -43,7 +43,7 @@ jobs:
 
   release-maven-public:
     name: release/maven-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.0
     with:
       flow-type: public
       java-version: "21"
@@ -52,7 +52,7 @@ jobs:
 
   release-maven-hybrid:
     name: release/maven-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: "21"

--- a/.github/workflows/security-reports.yml
+++ b/.github/workflows/security-reports.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
     with:
       java-version: '21'
       enable-dependency-check: false

--- a/.github/workflows/security-reports.yml
+++ b/.github/workflows/security-reports.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
     with:
       java-version: '21'
       enable-dependency-check: false

--- a/.github/workflows/security-reports.yml
+++ b/.github/workflows/security-reports.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.0
     with:
       java-version: '21'
       enable-dependency-check: false

--- a/.github/workflows/test-check-artifact.yml
+++ b/.github/workflows/test-check-artifact.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"
     secrets: inherit

--- a/.github/workflows/test-check-artifact.yml
+++ b/.github/workflows/test-check-artifact.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"
     secrets: inherit

--- a/.github/workflows/test-check-artifact.yml
+++ b/.github/workflows/test-check-artifact.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"
     secrets: inherit

--- a/.github/workflows/test-register-release.yml
+++ b/.github/workflows/test-register-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.2.0
+    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.3.5
     with:
       octopus-repository: ${{ inputs.octopus-repository }}
       release-version:  ${{ inputs.release-version }}

--- a/.github/workflows/test-register-release.yml
+++ b/.github/workflows/test-register-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.4.1
     with:
       octopus-repository: ${{ inputs.octopus-repository }}
       release-version:  ${{ inputs.release-version }}

--- a/.github/workflows/test-register-release.yml
+++ b/.github/workflows/test-register-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.4.0
     with:
       octopus-repository: ${{ inputs.octopus-repository }}
       release-version:  ${{ inputs.release-version }}


### PR DESCRIPTION
Aligns the **octopus-test canary** on the Phase 4 LTS pin `2.3.5` (was 2.2.0) so it validates the version actually being rolled out — a canary two lines behind is weak.

- **19 refs** across 12 workflows (build/quality/release/security/check-and-register + `release-smoke`) moved `@v2.2.0` → `@v2.3.5`. All pins are `octopusden/octopus-base/.github/workflows/*`; no plugin-version pin, no other refs touched.

⚠️ **Bigger jump than the other Batch A bumps** (2.2.0 → 2.3.5, spans several releases). This repo is the canary that exercises octopus-base's reusable-workflow contract, so **CI here is the real check** — if any workflow-input contract changed since 2.2.0 it will surface on this PR. Do not merge until green + reviewed. Part of Phase 4 Batch A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)