### PR TITLE
test(release): smoke-cover publish-to-nexus=false consumer contract

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -41,6 +41,25 @@ jobs:
       dry-run: true
     secrets: inherit
 
+  # Consumer canary for the publish-to-nexus=false contract, i.e. deployable-only repos that
+  # ship a docker image and are never consumed as a Maven dependency. Mirrors the
+  # hybrid-docker case but opts out of Sonatype publishing. Under dry-run the publish steps
+  # are skipped regardless of publish-to-nexus, so this verifies the caller contract — the
+  # input is accepted and the build/docker/register path stays green — not the live gating.
+  release-gradle-hybrid-docker-no-nexus:
+    name: release/gradle-hybrid-docker-no-nexus
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2
+    with:
+      flow-type: hybrid
+      java-version: "21"
+      commit-hash: ${{ github.sha }}
+      build-version: 0.0.0-smoke-${{ github.run_number }}
+      docker-image: octopus-test
+      publish-to-nexus: false
+      register-release-immediately: true
+      dry-run: true
+    secrets: inherit
+
   release-maven-public:
     name: release/maven-public
     uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.2

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -9,6 +9,12 @@ permissions:
 
 jobs:
   # Execute reusable release flows without publish side effects.
+  #
+  # Every job below passes `secrets: inherit`, deliberately: this suite is the consumer canary
+  # for common-java-gradle-release, so it must invoke that workflow the same way real callers do
+  # — all of them use `secrets: inherit`. Narrowing to an explicit secret map here would make the
+  # canary diverge from the contract it exists to verify, and could hide a missing-secret failure
+  # that a real release would hit. `dry-run: true` is what keeps these runs side-effect-free.
   release-gradle-public:
     name: release/gradle-public
     uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2


### PR DESCRIPTION
## Why

octopus-base v2.5.0/v2.5.1 added a `publish-to-nexus` input (default `true`) to `common-java-gradle-release` so deployable-only repos (e.g. the components-management-portal) can skip publishing their fat-jar to Maven Central — the org is over the Central monthly publishing limits. Per project rules the new caller contract needs consumer-canary coverage in `octopus-test`, which previously exercised only the default value.

## What

- Add smoke job `release/gradle-hybrid-docker-no-nexus`: mirrors the existing hybrid-docker case but with `publish-to-nexus: false` + `register-release-immediately: true` — the exact portal scenario.
- Bump the reusable release-workflow refs to `@v2.5.1` (carries the input plus the Central Portal API publish fix #166).

## Coverage scope (honest limitation)

The smoke suite runs everything under `dry-run: true` (no publish side effects). Under dry-run the publish step is skipped regardless of `publish-to-nexus`, so this canary verifies the **caller contract** — the input is accepted and the build/docker/register path stays green — not the live publish gating. That matches how the rest of the smoke suite works.

## Related

- octopusden/octopus-base#164 (the input) — merged, released in v2.5.0/v2.5.1
- octopusden/octopus-components-management-portal#203 (the first consumer setting it to `false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated release smoke tests to use the latest shared release workflow.
  * Added coverage for Gradle hybrid Docker releases that do not publish to Nexus.
  * Kept smoke validation in dry-run mode while ensuring release registration can occur immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->