### PR TITLE
chore(ci): bump octopus-base reusable workflows to 2.5.1

### DIFF
--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.5.1
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -21,21 +21,21 @@ jobs:
 
   build-gradle-public:
     name: build/gradle-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.1
     with:
       flow-type: public
       java-version: "21"
 
   build-gradle-hybrid:
     name: build/gradle-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.1
     with:
       flow-type: hybrid
       java-version: "21"
 
   build-gradle-hybrid-docker:
     name: build/gradle-hybrid-docker
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.1
     with:
       flow-type: hybrid
       java-version: "21"
@@ -43,7 +43,7 @@ jobs:
 
   build-maven-public:
     name: build/maven-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.5.1
     with:
       java-version: "21"
 

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.5.1
     with:
       java-version: '21'

--- a/.github/workflows/release-gradle-hybrid-docker.yml
+++ b/.github/workflows/release-gradle-hybrid-docker.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release-gradle-hybrid.yml
+++ b/.github/workflows/release-gradle-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
     with:
       flow-type: hybrid
       java-version: '21' 

--- a/.github/workflows/release-gradle-public.yml
+++ b/.github/workflows/release-gradle-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
     with:
       flow-type: public
       java-version: '21'

--- a/.github/workflows/release-maven-hybrid.yml
+++ b/.github/workflows/release-maven-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.1
     with:
       flow-type: hybrid
       java-version: '8'

--- a/.github/workflows/release-maven-public.yml
+++ b/.github/workflows/release-maven-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.1
     with:
       flow-type: public
       java-version: '21'

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -11,7 +11,7 @@ jobs:
   # Execute reusable release flows without publish side effects.
   release-gradle-public:
     name: release/gradle-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
     with:
       flow-type: public
       java-version: "21"
@@ -20,7 +20,7 @@ jobs:
 
   release-gradle-hybrid:
     name: release/gradle-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
     with:
       flow-type: hybrid
       java-version: "21"
@@ -31,7 +31,7 @@ jobs:
 
   release-gradle-hybrid-docker:
     name: release/gradle-hybrid-docker
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
     with:
       flow-type: hybrid
       java-version: "21"
@@ -43,7 +43,7 @@ jobs:
 
   release-maven-public:
     name: release/maven-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.1
     with:
       flow-type: public
       java-version: "21"
@@ -52,7 +52,7 @@ jobs:
 
   release-maven-hybrid:
     name: release/maven-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.1
     with:
       flow-type: hybrid
       java-version: "21"

--- a/.github/workflows/security-reports.yml
+++ b/.github/workflows/security-reports.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.5.1
     with:
       java-version: '21'
       enable-dependency-check: false

--- a/.github/workflows/test-check-artifact.yml
+++ b/.github/workflows/test-check-artifact.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.5.1
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"
     secrets: inherit

--- a/.github/workflows/test-register-release.yml
+++ b/.github/workflows/test-register-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.5.1
     with:
       octopus-repository: ${{ inputs.octopus-repository }}
       release-version:  ${{ inputs.release-version }}


### PR DESCRIPTION
Switches the canary to octopus-base **v2.5.1** — all twelve workflow references at once, the same way #44 moved this repository to 2.4.1.

**Why v2.5.1:** the OSSRH-compat promotion `closed → released` no longer completes inside the plugin's wait, so releases fail (and sometimes publish anyway, leaving a version on Central with no tag). v2.5.1 publishes through the Central Portal API instead and verifies every artifact on `repo1.maven.org` before creating the tag — octopusden/octopus-base#166.

## What this unlocks

This repository is where the flow can be tested for real. A TeamCity-driven release of octopus-test exercises the whole chain in production conditions, which neither the earlier canary run nor octopus-base's own release covered end to end:

| Link in the chain | Covered so far | Covered by a TeamCity release here |
|---|---|---|
| dispatch from TeamCity → GitHub | no | yes |
| upload + close on OSSRH-compat | yes | yes |
| Portal publish → `PUBLISHED` | yes | yes |
| per-artifact check on repo1 | yes | yes |
| tag + release registration | yes | yes |
| **TeamCity poller's own verdict** | **no** | **yes** |

**The open question is the last row.** `CallGitHubRelease` waits for the release tag with a budget of 10 minutes — sized when a release finished in about four. Measured on the new flow: 713 s for a single-artifact release, 1006 s for octopus-base's own. So the tag can now appear after the poller has already given up, and TeamCity would report a timeout on a release that actually succeeded. Better to see that here than on a component.

## Notes

- Version comes from the TeamCity payload in the hybrid flow; `2.2.37` is free on Central, so a release can run fresh.
- Dispatch types stay distinct (`release`, `release-docker`, `release-maven`), so one trigger fires exactly one workflow.
- The release-smoke matrix in the merge gate now exercises v2.5.1 in dry-run, where the publish chain is skipped by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
