### PR TITLE
ci: bump octopus-base 2.5.1 → 2.5.2

### DIFF
--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.5.2
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -21,21 +21,21 @@ jobs:
 
   build-gradle-public:
     name: build/gradle-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.2
     with:
       flow-type: public
       java-version: "21"
 
   build-gradle-hybrid:
     name: build/gradle-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: "21"
 
   build-gradle-hybrid-docker:
     name: build/gradle-hybrid-docker
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: "21"
@@ -43,7 +43,7 @@ jobs:
 
   build-maven-public:
     name: build/maven-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.5.2
     with:
       java-version: "21"
 

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.5.2
     with:
       java-version: '21'

--- a/.github/workflows/release-gradle-hybrid-docker.yml
+++ b/.github/workflows/release-gradle-hybrid-docker.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release-gradle-hybrid.yml
+++ b/.github/workflows/release-gradle-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: '21' 

--- a/.github/workflows/release-gradle-public.yml
+++ b/.github/workflows/release-gradle-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2
     with:
       flow-type: public
       java-version: '21'

--- a/.github/workflows/release-maven-hybrid.yml
+++ b/.github/workflows/release-maven-hybrid.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: '8'

--- a/.github/workflows/release-maven-public.yml
+++ b/.github/workflows/release-maven-public.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.2
     with:
       flow-type: public
       java-version: '21'

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -11,7 +11,7 @@ jobs:
   # Execute reusable release flows without publish side effects.
   release-gradle-public:
     name: release/gradle-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2
     with:
       flow-type: public
       java-version: "21"
@@ -20,7 +20,7 @@ jobs:
 
   release-gradle-hybrid:
     name: release/gradle-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: "21"
@@ -31,7 +31,7 @@ jobs:
 
   release-gradle-hybrid-docker:
     name: release/gradle-hybrid-docker
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: "21"
@@ -43,7 +43,7 @@ jobs:
 
   release-maven-public:
     name: release/maven-public
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.2
     with:
       flow-type: public
       java-version: "21"
@@ -52,7 +52,7 @@ jobs:
 
   release-maven-hybrid:
     name: release/maven-hybrid
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: "21"

--- a/.github/workflows/security-reports.yml
+++ b/.github/workflows/security-reports.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.5.2
     with:
       java-version: '21'
       enable-dependency-check: false

--- a/.github/workflows/test-check-artifact.yml
+++ b/.github/workflows/test-check-artifact.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.5.2
     with:
       artifact-pattern: "octopus-test/_VER_/octopus-test-_VER_.jar"
     secrets: inherit

--- a/.github/workflows/test-register-release.yml
+++ b/.github/workflows/test-register-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-register-release.yml@v2.5.2
     with:
       octopus-repository: ${{ inputs.octopus-repository }}
       release-version:  ${{ inputs.release-version }}


### PR DESCRIPTION
## What

Bumps every octopus-base reference from **v2.5.1 → v2.5.2** — 19 refs across 12 workflows, leaving nothing on the previous tag.

## Why

This repository is the canary for the shared release workflows, so it should sit on the version the components are being moved to. Consumer PRs adopting v2.5.2 are open for components-registry-service, api-gateway and cve-automation.

Between the two tags only the release path changed, and all of it matters here:

- **Registration resolves the released version differently.** It used to ask "what is the highest version tag in this repository?" — unrelated to what the triggering run released. This repository is where that bit: a leftover `v9.9.9` canary tag hijacked the real `2.2.37` release, so the log recorded 9.9.9, post-processing created bookkeeping for a version nobody released and set the stored latest version to 9.9.9, while `2.2.37` got nothing. The version now comes from the release that the triggering run stamped with its own id and attempt.
- **Registration is idempotent.** Both registration paths can be active at once — this repository has both — and each release-log entry triggers post-processing, so the same version was processed twice. A version already in the log is now skipped.
- **The maven release path** gained the same run stamp and now exposes its computed version, so the public flow no longer registers an empty string.

## Why it's safe

- `build`, `quality-gates` and `security-reports` are untouched between the tags, so the merge gate behaves exactly as it does today. The diff between `v2.5.1` and `v2.5.2` covers only the four release-path workflows.
- No sources, build logic or baselines change here — only workflow refs.
- The release smoke matrix and both consumer-contract test workflows are bumped together with the release workflows, so nothing is left verifying an older contract.

## Verification behind v2.5.2

- **This repository released `2.2.37`** end to end from the internal CI on v2.5.1: Portal deployment reached `PUBLISHED`, the artifact was confirmed resolvable on Maven Central, the tag was created, the release was registered and post-processing ran.
- **octopus-base released `2.5.2`** through the same path, with consumer verification against this repository before publishing, and both published coordinates confirmed on Maven Central afterwards.
- The stale `v9.9.9` and `v9.9.9-pr99` canary tags and the bogus release-log entry from the incident above were removed, so the highest tag here is a real release again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shared build, quality, security, testing, and release workflows to version 2.5.2.
  * Preserved existing workflow settings, inputs, permissions, triggers, and release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->