### PR TITLE
chore(publish): publish the thin jar, not the 20 MB bootJar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,14 @@ nexusPublishing {
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {
-            artifact(tasks.named("bootJar"))
+            // Publish the THIN jar, not the bootJar. This repository is the release-workflow
+            // canary; nothing consumes its artifacts as a dependency, yet every test release was
+            // uploading a ~20 MB Spring Boot executable jar to Maven Central — 91 versions, ~1.45 GB
+            // in total, and ~41 MB of the org's 80 MB monthly quota in July 2026 alone.
+            // The classifier is cleared so the published coordinate keeps the classifier-less name
+            // that check-and-register.yml and test-check-artifact.yml poll. bootJar itself is
+            // untouched: the docker image build still uses it.
+            artifact(tasks.named("jar")) { classifier = "" }
             artifact(tasks["sourcesJar"])
             artifact(tasks["javadocJar"])
             pom {


### PR DESCRIPTION
## Why

This repository is the release-workflow **canary** — nothing consumes its artifacts as a Maven dependency — yet every test release uploaded a Spring Boot **executable** jar to Maven Central.

Measured against repo1:

| | |
|---|--:|
| versions published | **91** |
| total size of main jars | **1.45 GB** |
| average per version | 16.3 MB (latest: 20.6 MB) |
| **published in July 2026** | **2 versions = 41 MB** |

The org is currently **over** Central's monthly limits (Release Size 1.21 GB vs 80 MB), so the canary alone was consuming **half the monthly quota** — on artifacts that exist only to prove the pipeline works.

## What

Publish the **thin** jar instead of the bootJar: **2.9 KB** against 20.6 MB. The release path is still exercised end to end, at ~0.5% of the cost.

Two details that keep this a no-op for everything else:

- **The coordinate name is unchanged.** Spring Boot gives the plain jar a `plain` classifier, so the publication clears it — `octopus-test-<version>.jar` still resolves, which is what `check-and-register.yml:14` and `test-check-artifact.yml:9` poll (`octopus-test/_VER_/octopus-test-_VER_.jar`).
- **`bootJar` is untouched.** The docker image build still uses it, and nothing in the repository requires the *published* jar to be executable — the only reference to `bootJar` anywhere was the publication line itself.

## Verification

`./gradlew publishToMavenLocal -Pnexus=true -Dmaven.repo.local=…` produces exactly:

```
octopus-test-0.0.0-thin.jar            2.9K   ← was 20.6 MB, name preserved
octopus-test-0.0.0-thin-sources.jar    1.5K
octopus-test-0.0.0-thin-javadoc.jar     92K
octopus-test-0.0.0-thin.pom            1.3K
```

## Context

This also unblocks octopusden/octopus-base#177, which adds a pre-upload guard that fails a release when a fat jar would reach Central. Its consumer-verify canary currently fails **correctly** — because this repository publishes a 20.6 MB bootJar. Aligning the consumer first is the right order; the alternative (an allowlist entry here) isn't even possible yet, since that input only exists in an unreleased octopus-base version while this repository pins `@v2.5.2`.

Independent of #177 otherwise — this works on the currently pinned version and can merge on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)